### PR TITLE
implement oidc for door routes and move to esm

### DIFF
--- a/access.js
+++ b/access.js
@@ -1,0 +1,23 @@
+export async function checkAccess(db, userId, doorId) {
+  const dbUser = await db.collection("users").findOne({ id: { $eq: userId } });
+  if (!dbUser) return undefined;
+  if (dbUser.disabled) return false;
+
+  const userTicket = await db.collection("userTickets").findOne(
+    {
+      userId: { $in: [userId, "*"] },
+      doorId: { $in: [doorId, "*"] },
+    },
+    { sort: { priority: -1 } }
+  );
+  if (userTicket !== null) return userTicket.granted;
+
+  const groupTicket = await db.collection("groupTickets").findOne(
+    {
+      doorId: { $in: ["*", doorId] },
+      groupId: { $in: dbUser.groups ? dbUser.groups.concat("*") : ["*"] },
+    },
+    { sort: { priority: -1 } }
+  );
+  return groupTicket?.granted;
+}

--- a/auth.js
+++ b/auth.js
@@ -1,7 +1,7 @@
 const realms = {
-  admin: new Set(process.env.GK_ADMIN_SECRETS.split(",")),
-  drink: new Set(process.env.GK_DRINK_SECRETS.split(",")),
-  projects: new Set(process.env.GK_MEMBER_PROJECT_SECRETS.split(",")),
+  admin: new Set((process.env.GK_ADMIN_SECRETS || "").split(",")),
+  drink: new Set((process.env.GK_DRINK_SECRETS || "").split(",")),
+  projects: new Set((process.env.GK_MEMBER_PROJECT_SECRETS || "").split(",")),
 };
 
 function generateMiddleware(realm) {
@@ -28,4 +28,8 @@ function generateMiddleware(realm) {
   return authMiddleware;
 }
 
-module.exports = generateMiddleware;
+export function checkSecret(realm, value) {
+  return realms[realm]?.has(value) ?? false;
+}
+
+export default generateMiddleware;

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,1 @@
+export const REALM_NAMES = ["doors", "drink", "memberProjects"];

--- a/ldap.js
+++ b/ldap.js
@@ -22,6 +22,7 @@ export function searchOne(base, filter, attributes) {
         if (err) {
           reject(err);
         } else {
+          // Don't leak memory:
           function onSearchEntry(entry) {
             resolve(entry);
             res.removeListener("end", onEnd);

--- a/ldap.js
+++ b/ldap.js
@@ -1,17 +1,51 @@
-const dns = require("dns");
-const util = require("util");
-const ldap = require("ldapjs");
-const resolve = util.promisify(dns.resolveSrv);
+import dns from "dns";
+import { promisify } from "util";
+import ldapjs from "ldapjs";
+
+const resolve = promisify(dns.resolveSrv);
 
 // TODO: This is a race condition!
+export let client;
+
+export function searchOne(base, filter, attributes) {
+  return new Promise((resolve, reject) => {
+    client.search(
+      base,
+      {
+        filter,
+        scope: "one",
+        paged: false,
+        sizeLimit: 1,
+        ...(attributes && { attributes }),
+      },
+      (err, res) => {
+        if (err) {
+          reject(err);
+        } else {
+          function onSearchEntry(entry) {
+            resolve(entry);
+            res.removeListener("end", onEnd);
+          }
+          function onEnd() {
+            res.removeListener("searchEntry", onSearchEntry);
+            reject(new Error("User not found!"));
+          }
+          res.once("searchEntry", onSearchEntry);
+          res.once("end", onEnd);
+        }
+      }
+    );
+  });
+}
+
 resolve("_ldap._tcp.csh.rit.edu").then((records) => {
-  module.exports.client = ldap.createClient({
+  client = ldapjs.createClient({
     url: records.map((record) => `ldap://${record.name}:${record.port}`),
     reconnect: true,
   });
-  module.exports.client.on("connect", () => {
+  client.on("connect", () => {
     console.log("Client connected. Binding...");
-    module.exports.client.bind(
+    client.bind(
       process.env.GK_LDAP_BIND_DN,
       process.env.GK_LDAP_PASSWORD,
       (err) => {

--- a/middleware/hybridAuth.js
+++ b/middleware/hybridAuth.js
@@ -1,0 +1,29 @@
+import { validateToken } from "./oidc.js";
+import { checkSecret } from "../auth.js";
+
+export function hybridAuth(realm) {
+  return async function (req, res, next) {
+    const authHeader = req.headers.authorization;
+    if (!authHeader) {
+      return res.status(401).json({ message: "Authorization required" });
+    }
+
+    if (authHeader.startsWith("Bearer ")) {
+      try {
+        req.ctx.userId = await validateToken(authHeader.slice(7));
+        req.ctx.authMethod = "oidc";
+        next();
+      } catch (err) {
+        return res.status(err.status || 401).json({ message: err.message });
+      }
+    } else {
+      if (!checkSecret(realm, authHeader)) {
+        return res.status(403).json({
+          message: "Unknown application! Are you on the wrong realm?",
+        });
+      }
+      req.ctx.authMethod = "secret";
+      next();
+    }
+  };
+}

--- a/middleware/oidc.js
+++ b/middleware/oidc.js
@@ -1,0 +1,71 @@
+import { discovery } from "openid-client";
+import { createRemoteJWKSet, jwtVerify } from "jose";
+
+const REQUIRED_SCOPE = "gatekeeper_provision";
+const USER_ID_CLAIM = "ipaUniqueID";
+
+const issuerUrl = new URL(
+  process.env.GK_OIDC_ISSUER || "https://sso.csh.rit.edu/auth/realms/csh"
+);
+export const clientId = process.env.GK_OIDC_CLIENT_ID;
+
+export const oidcPromise = discovery(issuerUrl, clientId).then((config) => {
+  const metadata = config.serverMetadata();
+  return {
+    issuer: metadata.issuer,
+    JWKS: createRemoteJWKSet(new URL(metadata.jwks_uri)),
+  };
+});
+
+class AuthError extends Error {
+  constructor(message, status) {
+    super(message);
+    this.status = status;
+  }
+}
+
+// Validates a Bearer token and returns userId.
+// Pass requiredScope to enforce a specific scope claim.
+export async function validateToken(token, requiredScope = null) {
+  const { issuer, JWKS } = await oidcPromise;
+  const verifyOptions = { issuer };
+  if (clientId) verifyOptions.audience = clientId;
+
+  let payload;
+  try {
+    ({ payload } = await jwtVerify(token, JWKS, verifyOptions));
+  } catch (err) {
+    throw new AuthError("Invalid or expired token", 401);
+  }
+
+  if (requiredScope) {
+    const scopes =
+      typeof payload.scope === "string" ? payload.scope.split(" ") : [];
+    if (!scopes.includes(requiredScope)) {
+      throw new AuthError(
+        `Token missing required scope: ${requiredScope}`,
+        403
+      );
+    }
+  }
+
+  const userId = payload[USER_ID_CLAIM];
+  if (!userId) {
+    throw new AuthError(`Token missing required claim: ${USER_ID_CLAIM}`, 403);
+  }
+
+  return userId;
+}
+
+export async function oidcAuth(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith("Bearer ")) {
+    return res.status(401).json({ message: "Bearer token required" });
+  }
+  try {
+    req.ctx.userId = await validateToken(authHeader.slice(7), REQUIRED_SCOPE);
+    next();
+  } catch (err) {
+    return res.status(err.status || 401).json({ message: err.message });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "gatekeeper-mqtt",
   "version": "1.0.0",
+  "type": "module",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -12,10 +13,11 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
+    "jose": "^5.0.0",
     "ldapjs": "^2.3.1",
     "mongodb": "^7.1.0",
     "morgan": "^1.10.0",
     "mqtt": "^4.2.6",
-    "node-fetch": "^3.2.10"
+    "openid-client": "^6.0.0"
   }
 }

--- a/routes/doors.js
+++ b/routes/doors.js
@@ -1,5 +1,8 @@
-const router = require("express").Router();
-const {doorHeartbeats} = require("../state.js");
+import { Router } from "express";
+import { doorHeartbeats } from "../state.js";
+import { checkAccess } from "../access.js";
+
+const router = Router();
 
 router.get("/:doorId/status", (req, res) => {
   // If it's been more than 1 minute, we assume something is broken...
@@ -32,8 +35,18 @@ router.get("/", async (req, res) => {
 });
 
 router.post("/:doorId/unlock", async (req, res) => {
+  if (req.ctx.authMethod === "oidc") {
+    const granted = await checkAccess(
+      req.ctx.db,
+      req.ctx.userId,
+      req.params.doorId
+    );
+    if (!granted) {
+      return res.status(403).json({ message: "Access denied" });
+    }
+  }
   req.ctx.mqtt.publish(`gk/${req.params.doorId}/unlock`, "");
   res.status(204).send(null);
 });
 
-module.exports = router;
+export default router;

--- a/routes/keys.js
+++ b/routes/keys.js
@@ -1,7 +1,8 @@
-const router = require("express").Router();
-const crypto = require("crypto");
+import { Router } from "express";
+import crypto from "crypto";
+import { REALM_NAMES } from "../constants.js";
 
-const REALM_NAMES = ["doors", "drink", "memberProjects"];
+const router = Router();
 
 // First, PUT /keys with details of user key is for
 // Receive a keyId back which is our association
@@ -119,4 +120,4 @@ router.delete("/:keyId", async (req, res) => {
   }
 });
 
-module.exports = router;
+export default router;

--- a/routes/memberProjects.js
+++ b/routes/memberProjects.js
@@ -1,36 +1,9 @@
-const router = require("express").Router();
-const ldap = require("../ldap");
+import { Router } from "express";
+import { searchOne } from "../ldap.js";
 
-function findUser(id) {
-  return new Promise((resolve, reject) => {
-    ldap.client.search(
-      "cn=users,cn=accounts,dc=csh,dc=rit,dc=edu",
-      {
-        filter: `(ipaUniqueID=${id})`,
-        scope: "one",
-        paged: false,
-        sizeLimit: 1,
-      },
-      (err, res) => {
-        if (err) {
-          reject(err);
-        } else {
-          // Don't leak memory:
-          function onSearchEntry(entry) {
-            resolve(entry);
-            res.removeListener("end", onEnd);
-          }
-          function onEnd() {
-            res.removeListener("searchEntry", onSearchEntry);
-            reject(new Error("User not found!"));
-          }
-          res.once("searchEntry", onSearchEntry);
-          res.once("end", onEnd);
-        }
-      }
-    );
-  });
-}
+const router = Router();
+
+const USER_BASE = "cn=users,cn=accounts,dc=csh,dc=rit,dc=edu";
 
 const ARRAYS = new Set([
   "memberOf",
@@ -39,6 +12,7 @@ const ARRAYS = new Set([
   "ipaSshPubKey",
   "ibutton",
 ]);
+
 router.get("/by-key/:associationId", async (req, res) => {
   const key = await req.ctx.db.collection("keys").findOne({
     [req.associationType]: {$eq: req.params.associationId},
@@ -60,7 +34,7 @@ router.get("/by-key/:associationId", async (req, res) => {
 
   let user;
   try {
-    user = await findUser(key.userId);
+    user = await searchOne(USER_BASE, `(ipaUniqueID=${key.userId})`);
   } catch (err) {
     res.status(500).json({message: "Internal server error"});
     return;
@@ -88,4 +62,4 @@ router.get("/by-key/:associationId", async (req, res) => {
   });
 });
 
-module.exports = router;
+export default router;

--- a/routes/mobile.js
+++ b/routes/mobile.js
@@ -1,89 +1,14 @@
-const express = require("express");
-const crypto = require("crypto");
-const router = express.Router();
-const ldap = require("../ldap");
-const fetchPromise = import("node-fetch");
+import { Router } from "express";
+import crypto from "crypto";
+import { oidcAuth } from "../middleware/oidc.js";
+import { REALM_NAMES } from "../constants.js";
 
-const REALM_NAMES = ["doors", "drink", "memberProjects"];
+const router = Router();
 
-function findUser(filter) {
-  return new Promise((resolve, reject) => {
-    ldap.client.search(
-      "cn=users,cn=accounts,dc=csh,dc=rit,dc=edu",
-      {
-        filter,
-        scope: "one",
-        attributes: ["ipaUniqueID", "nsAccountLock"],
-        paged: false,
-        sizeLimit: 1,
-      },
-      (err, res) => {
-        if (err) {
-          reject(err);
-        } else {
-          // Don't leak memory:
-          function onSearchEntry(entry) {
-            resolve(entry);
-            res.removeListener("end", onEnd);
-          }
-          function onEnd() {
-            res.removeListener("searchEntry", onSearchEntry);
-            reject(new Error("User not found!"));
-          }
-          res.once("searchEntry", onSearchEntry);
-          res.once("end", onEnd);
-        }
-      },
-    );
-  });
-}
-
-router.use(async (req, response, next) => {
-  const fetch = (await fetchPromise).default;
-  if (!req.headers.authorization) {
-    response.status(401).send("No authorization header");
-    return;
-  }
-  const tokenParts = req.headers.authorization.split(" ");
-  if (tokenParts.length != 2) {
-    response.status(401).send("Invalid authorization header");
-    return;
-  }
-  const parts = tokenParts[1].split(".");
-  if (parts.length != 3) {
-    response.status(401).send("Invalid authorization header");
-    return;
-  }
-  const payload = JSON.parse(Buffer.from(parts[1], "base64").toString("utf8"));
-  if (!payload.scope.split(" ").includes("gatekeeper_provision")) {
-    response
-      .status(403)
-      .send("Tokens issued for other clients are not allowed");
-    return;
-  }
-  const res = await fetch(
-    "https://sso.csh.rit.edu/auth/realms/csh/protocol/openid-connect/userinfo",
-    {
-      headers: {
-        Authorization: req.headers.authorization,
-      },
-    },
-  );
-  if (res.status != 200) {
-    response.status(403).send("Unauthorized");
-    return;
-  }
-  const user = await res.json();
-  req.ctx.user = user;
-  const ipaUser = await findUser(`uid=${user.preferred_username}`);
-  req.ctx.userId = ipaUser.attributes
-    .find((attribute) => attribute.type == "ipaUniqueID")
-    ._vals[0].toString("utf8");
-  next();
-});
+router.use(oidcAuth);
 
 router.get("/provision", async (req, res) => {
-  const stem = {userId: req.ctx.userId, mobile: true};
+  const stem = { userId: req.ctx.userId, mobile: true };
   let key = await req.ctx.db.collection("keys").findOne(stem);
   if (!key) {
     key = {
@@ -95,7 +20,6 @@ router.get("/provision", async (req, res) => {
     for (const name of REALM_NAMES) {
       key[name + "Id"] = crypto.randomBytes(18).toString("hex");
     }
-
     await req.ctx.db.collection("keys").insertOne(key);
   }
   const output = {};
@@ -105,4 +29,4 @@ router.get("/provision", async (req, res) => {
   res.json(output);
 });
 
-module.exports = router;
+export default router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,38 +1,11 @@
-const router = require("express").Router();
-const ldap = require("../ldap");
-const {syncUser} = require("../sync");
+import { Router } from "express";
+import { searchOne } from "../ldap.js";
+import { syncUser } from "../sync.js";
 
-function findUser(filter) {
-  return new Promise((resolve, reject) => {
-    ldap.client.search(
-      "cn=users,cn=accounts,dc=csh,dc=rit,dc=edu",
-      {
-        filter,
-        scope: "one",
-        attributes: ["memberOf", "ipaUniqueID", "nsAccountLock"],
-        paged: false,
-        sizeLimit: 1,
-      },
-      (err, res) => {
-        if (err) {
-          reject(err);
-        } else {
-          // Don't leak memory:
-          function onSearchEntry(entry) {
-            resolve(entry);
-            res.removeListener("end", onEnd);
-          }
-          function onEnd() {
-            res.removeListener("searchEntry", onSearchEntry);
-            reject(new Error("User not found!"));
-          }
-          res.once("searchEntry", onSearchEntry);
-          res.once("end", onEnd);
-        }
-      }
-    );
-  });
-}
+const router = Router();
+
+const USER_BASE = "cn=users,cn=accounts,dc=csh,dc=rit,dc=edu";
+const USER_ATTRS = ["memberOf", "ipaUniqueID", "nsAccountLock"];
 
 function validId(id) {
   return id.match(/^[a-zA-Z0-9\-]+$/m);
@@ -49,7 +22,7 @@ router.get("/:id", async (req, res) => {
   if (!user) {
     let userData = null;
     try {
-      userData = await findUser(`(ipaUniqueID=${req.body.id})`);
+      userData = await searchOne(USER_BASE, `(ipaUniqueID=${req.body.id})`, USER_ATTRS);
     } catch (err) {
       res.status(404).json({message: "Not found"});
     }
@@ -72,8 +45,7 @@ router.get("/uuid-by-uid/:uid", async (req, res) => {
   }
   console.log("uuid by uid:", req.params.uid);
   try {
-    const user = await findUser(`(uid=${req.params.uid})`);
-    // Ensure we're updated on DB-side
+    const user = await searchOne(USER_BASE, `(uid=${req.params.uid})`, USER_ATTRS);
     const userDocument = await syncUser(req.ctx.db, user);
     console.log("Got user", userDocument);
 
@@ -89,4 +61,4 @@ router.get("/uuid-by-uid/:uid", async (req, res) => {
   }
 });
 
-module.exports = router;
+export default router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -46,6 +46,7 @@ router.get("/uuid-by-uid/:uid", async (req, res) => {
   console.log("uuid by uid:", req.params.uid);
   try {
     const user = await searchOne(USER_BASE, `(uid=${req.params.uid})`, USER_ATTRS);
+    // Ensure we're updated on DB-side
     const userDocument = await syncUser(req.ctx.db, user);
     console.log("Got user", userDocument);
 

--- a/server.js
+++ b/server.js
@@ -17,6 +17,7 @@ import keys from "./routes/keys.js";
 import users from "./routes/users.js";
 import mobile from "./routes/mobile.js";
 
+//fetch user from the https endpoint
 async function fetchUser(endpoint, token, memberProjectsId) {
   const url = new URL(`${endpoint}/projects/by-key/${memberProjectsId}`);
   const res = await fetch(url, {
@@ -151,8 +152,9 @@ connectionPromise.then(async () => {
         doorsId: {$eq: payload.association},
         enabled: {$eq: true},
       });
+      // Doesn't exist??
       if (!key) return;
-
+      // Fetch user info from HTTP endpoint
       const endpoint = process.env.GK_HTTP_ENDPOINT;
       const token = process.env.GK_SERVER_TOKEN;
 
@@ -177,6 +179,7 @@ connectionPromise.then(async () => {
       const user = userData?.user || {};
       const username = user.uid || null;
       const name = user.cn || null;
+      // Resolve door name
       const doorName = doorDoc?.name || null;
 
       //timestamps (DUHHH?)

--- a/server.js
+++ b/server.js
@@ -1,61 +1,35 @@
-const express = require("express");
-const mqtt = require("mqtt");
-const mongo = require("mongodb");
-const bodyParser = require("body-parser");
-const morgan = require("morgan");
+import express from "express";
+import mqtt from "mqtt";
+import { MongoClient, ObjectId } from "mongodb";
+import bodyParser from "body-parser";
+import morgan from "morgan";
 
-const {doorHeartbeats} = require("./state");
-const {syncUsers} = require("./sync");
-
-const auth = require("./auth");
+import { doorHeartbeats } from "./state.js";
+import { syncUsers } from "./sync.js";
+import auth from "./auth.js";
+import { hybridAuth } from "./middleware/hybridAuth.js";
+import { checkAccess } from "./access.js";
 
 // API routes
-const memberProjects = require("./routes/memberProjects");
-const doors = require("./routes/doors");
-const keys = require("./routes/keys");
-const users = require("./routes/users");
-const mobile = require("./routes/mobile");
+import memberProjects from "./routes/memberProjects.js";
+import doors from "./routes/doors.js";
+import keys from "./routes/keys.js";
+import users from "./routes/users.js";
+import mobile from "./routes/mobile.js";
 
-const https = require("https");
-//fetch user from the https endpoint
-function fetchUser(endpoint, token, memberProjectsId) {
-  return new Promise((resolve, reject) => {
-    const url = new URL(`${endpoint}/projects/by-key/${memberProjectsId}`);
-
-    const req = https.request(
-      url,
-      {
-        method: "GET",
-        headers: {
-          Authorization: token,
-        },
-      },
-      (res) => {
-        let data = "";
-
-        res.on("data", (chunk) => (data += chunk));
-
-        res.on("end", () => {
-          if (res.statusCode === 200) {
-            try {
-              resolve(JSON.parse(data));
-            } catch {
-              reject(new Error("Invalid JSON response"));
-            }
-          } else {
-            reject(new Error(`HTTP ${res.statusCode}`));
-          }
-        });
-      }
-    );
-
-    req.on("error", reject);
-    req.end();
+async function fetchUser(endpoint, token, memberProjectsId) {
+  const url = new URL(`${endpoint}/projects/by-key/${memberProjectsId}`);
+  const res = await fetch(url, {
+    headers: { Authorization: token },
   });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return res.json();
 }
 
 // Apparently, automatic reconnection is the default!
-const mongoClient = new mongo.MongoClient(process.env.GK_MONGO_SERVER, {
+const mongoClient = new MongoClient(process.env.GK_MONGO_SERVER, {
   maxPoolSize: 0,
   minPoolSize: 0,
 });
@@ -64,10 +38,12 @@ connectionPromise.then(async () => {
   console.log("DB Connection opened!");
   const db = mongoClient.db("gatekeeper");
 
-  await db.collection("users").createIndex("id", {unique: true});
-  await db.collection("keys").createIndex("doorsId", {unique: true});
-  await db.collection("keys").createIndex("drinkId", {unique: true});
-  await db.collection("keys").createIndex("memberProjectsId", {unique: true});
+  await Promise.all([
+    db.collection("users").createIndex("id", {unique: true}),
+    db.collection("keys").createIndex("doorsId", {unique: true}),
+    db.collection("keys").createIndex("drinkId", {unique: true}),
+    db.collection("keys").createIndex("memberProjectsId", {unique: true}),
+  ]);
 
   async function scheduledTasks() {
     console.log("Scheduled task time!");
@@ -142,7 +118,7 @@ connectionPromise.then(async () => {
     },
     memberProjects
   );
-  app.use("/doors", auth("admin"), doors);
+  app.use("/doors", hybridAuth("admin"), doors);
   app.use("/admin/keys", auth("admin"), keys);
   app.use("/admin/users", auth("admin"), users);
   app.use("/mobile", mobile);
@@ -159,7 +135,7 @@ connectionPromise.then(async () => {
     }
   });
 
-client.on("message", async (topic, message) => {
+  client.on("message", async (topic, message) => {
     console.log("Got a message from server", topic, message);
     let payload;
     try {
@@ -175,84 +151,33 @@ client.on("message", async (topic, message) => {
         doorsId: {$eq: payload.association},
         enabled: {$eq: true},
       });
-      // Doesn't exist??
       if (!key) return;
-      // Fetch user info from HTTP endpoint
-      let userData = {};
+
       const endpoint = process.env.GK_HTTP_ENDPOINT;
       const token = process.env.GK_SERVER_TOKEN;
-      if (endpoint && token) {
-        try {
-          userData = await fetchUser(endpoint, token, key.memberProjectsId);
-        } catch (err) {
-          console.error("User fetch failed:", err.message);
-        }
-      }
+
+      const [userData, doorDoc, granted] = await Promise.all([
+        endpoint && token
+          ? fetchUser(endpoint, token, key.memberProjectsId).catch((err) => {
+              console.error("User fetch failed:", err.message);
+              return {};
+            })
+          : Promise.resolve({}),
+        db.collection("doors").findOne({
+          $or: [
+            { _id: doorId },
+            ...(ObjectId.isValid(doorId)
+              ? [{ _id: new ObjectId(doorId) }]
+              : []),
+          ],
+        }),
+        checkAccess(db, key.userId, doorId),
+      ]);
+
       const user = userData?.user || {};
       const username = user.uid || null;
       const name = user.cn || null;
-
-      const dbUser = await db.collection("users").findOne({
-        id: {$eq: key.userId },
-      });
-      if (!dbUser) {
-        console.log("No user found for key?", key);
-        return;
-      }
-      // Resolve door name
-      let doorName = null;
-      const doorDoc = await db.collection("doors").findOne({
-        $or: [
-          { _id: doorId },
-          ...(mongo.ObjectId.isValid(doorId)
-            ? [{ _id: new mongo.ObjectId(doorId) }]
-            : []),
-        ],
-      });
-      doorName = doorDoc?.name || null;
-      // Determine access
-      let granted = undefined;
-      if (dbUser.disabled) {
-        granted = false;
-      }
-      // This could be an `else if`, but this feels a little more consistent / cleaner
-      if (granted === undefined) {
-        const userTicket = await db.collection("userTickets").findOne(
-          {
-            userId: {$in: [key.userId, "*"]},
-            doorId: {$in: [doorId, "*"]},
-          },
-          {
-            sort: {
-              priority: -1,
-            },
-          }
-        );
-        console.log(userTicket);
-        granted = userTicket?.granted;
-      }
-      if (granted === undefined) {
-        const groupTicket = await db.collection("groupTickets").findOne(
-          {
-            doorId: {
-              $in: ["*", doorId],
-            },
-            groupId: {
-              $in: dbUser.groups ? dbUser.groups.concat("*") : ["*"],
-            },
-          },
-          { 
-            sort: {
-              priority: -1,
-            },
-          }
-        );
-        console.log(
-          `Found a group ticket for door=${doorId}/user=${dbUser.id} pair!`,
-          groupTicket
-        );
-        granted = groupTicket?.granted;
-      }
+      const doorName = doorDoc?.name || null;
 
       //timestamps (DUHHH?)
       const timestamp = new Date().toLocaleString("en-US", {

--- a/state.js
+++ b/state.js
@@ -1,4 +1,1 @@
-module.exports = {
-  // Stored in memory because it doesn't seem reasonable to put it in DB
-  doorHeartbeats: new Map(),
-};
+export const doorHeartbeats = new Map();

--- a/state.js
+++ b/state.js
@@ -1,1 +1,2 @@
+// Stored in memory because it doesn't seem reasonable to put it in DB
 export const doorHeartbeats = new Map();

--- a/sync.js
+++ b/sync.js
@@ -35,7 +35,8 @@ export async function syncUsers(db) {
   const cursor = await iterableSearch(
     "cn=users,cn=accounts,dc=csh,dc=rit,dc=edu",
     {
-      scope: "one",
+      // filter: "(uid)",
+      scope: "one", // one level under user DN (no need to recurse)
       paged: true,
       timeLimit: 60 * 30, // 30 minutes
       attributes: ["memberOf", "ipaUniqueID", "nsAccountLock"],
@@ -44,6 +45,9 @@ export async function syncUsers(db) {
   );
 
   const promises = [];
+  // Some day these should be batched...
+  // Maybe we could have a map of Group[] => User[] and use `updateMany`?
+  // This won't let us upsert, but that should be okay because enroll will fix it?
   for await (const user of cursor) {
     if (!user.attributes.find((attribute) => attribute.type == "ipaUniqueID")) {
       console.log("Missing attributes!", user);

--- a/sync.js
+++ b/sync.js
@@ -1,6 +1,6 @@
-const {iterableSearch} = require("./util");
+import { iterableSearch } from "./util.js";
 
-async function syncUser(db, user) {
+export async function syncUser(db, user) {
   const id = user.attributes
     .find((attribute) => attribute.type == "ipaUniqueID")
     ._vals[0].toString("utf8");
@@ -30,26 +30,20 @@ async function syncUser(db, user) {
   return {...document, id};
 }
 
-async function syncUsers(db) {
+export async function syncUsers(db) {
   console.log("Running sync job!");
   const cursor = await iterableSearch(
     "cn=users,cn=accounts,dc=csh,dc=rit,dc=edu",
     {
-      // filter: "(uid)",
-      scope: "one", // one level under user DN (no need to recurse)
+      scope: "one",
       paged: true,
       timeLimit: 60 * 30, // 30 minutes
       attributes: ["memberOf", "ipaUniqueID", "nsAccountLock"],
       sizeLimit: 0, // unlimited
     }
   );
-  console.log(cursor);
 
-  let userCount = 0;
   const promises = [];
-  // Some day these should be batched...
-  // Maybe we could have a map of Group[] => User[] and use `updateMany`?
-  // This won't let us upsert, but that should be okay because enroll will fix it?
   for await (const user of cursor) {
     if (!user.attributes.find((attribute) => attribute.type == "ipaUniqueID")) {
       console.log("Missing attributes!", user);
@@ -60,7 +54,3 @@ async function syncUsers(db) {
   await Promise.all(promises);
   console.log(`Synced ${promises.length} users!`);
 }
-module.exports = {
-  syncUsers,
-  syncUser,
-};

--- a/util.js
+++ b/util.js
@@ -1,6 +1,6 @@
-const ldap = require("./ldap");
+import * as ldap from "./ldap.js";
 
-function iterableSearch(base, options) {
+export function iterableSearch(base, options) {
   return new Promise((resolve, reject) => {
     ldap.client.search(base, options, (err, res) => {
       if (err) {
@@ -46,9 +46,7 @@ function iterableSearch(base, options) {
               while (entries.length) {
                 const entriesClone = entries;
                 entries = [];
-                // console.log(`Pumping ${entriesClone.length} entries!`);
                 yield* entriesClone;
-                // console.log("Pumped!");
               }
               if (!foundEnd) {
                 // Waits for next chunk to be dispatched from the system
@@ -72,6 +70,3 @@ function iterableSearch(base, options) {
     });
   });
 }
-module.exports = {
-  iterableSearch,
-};

--- a/util.js
+++ b/util.js
@@ -46,8 +46,9 @@ export function iterableSearch(base, options) {
               while (entries.length) {
                 const entriesClone = entries;
                 entries = [];
+                // console.log(`Pumping ${entriesClone.length} entries!`);
                 yield* entriesClone;
-              }
+                // console.log("Pumped!");
               if (!foundEnd) {
                 // Waits for next chunk to be dispatched from the system
                 await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Overhaul OIDC auth, add SSO to `/doors`, convert to ESM

### Auth fixes (`/mobile`)

The previous implementation decoded the JWT without verifying the signature; depending entirely on a Keycloak `userinfo` call per request. Replaced with proper local JWT verification via `openid-client` v6 + `jose`: signature, `iss`, `aud`, `exp`, and `nbf` validated against a cached JWKS. `ipaUniqueID` is now read directly from the token claim, eliminating the LDAP lookup and userinfo round-trip.

### SSO on `/doors`

The admin shared secret continues to work unchanged. SSO tokens are now also accepted via `middleware/hybridAuth.js`:

- `Authorization: Bearer <token>` → OIDC validation, sets `authMethod: 'oidc'`
- Anything else → existing secret check, sets `authMethod: 'secret'`

`POST /doors/:doorId/unlock` enforces the existing ticket model for SSO users (`userTickets` → `groupTickets` waterfall). Secret-authenticated requests bypass the ticket check as before. Read routes accept either auth method with no additional check.

The ticket logic is extracted from the MQTT handler into a shared `checkAccess(db, userId, doorId)` helper used by both the HTTP endpoint and the MQTT handler.

### ESM conversion

`openid-client` v6 and `jose` v5 are ESM-only. The project is converted to `"type": "module"` — all `require`/`module.exports` replaced with `import`/`export`. `node-fetch` is dropped in favor of Node 22 native `fetch`.

### New env vars

| Variable | Default | Description |
|---|---|---|
| `GK_OIDC_ISSUER` | `https://sso.csh.rit.edu/auth/realms/csh` | OIDC issuer |
| `GK_OIDC_CLIENT_ID` | — | Keycloak client ID for `aud` validation |

Keycloak must be configured to include `ipaUniqueID` as a claim in the access token.
