### PR TITLE
fix: enforce group-based auth on admin routes

### DIFF
--- a/middleware/hybridAuth.js
+++ b/middleware/hybridAuth.js
@@ -1,4 +1,4 @@
-import { validateToken } from "./oidc.js";
+import { validateToken, REQUIRED_SCOPE } from "./oidc.js";
 import { checkSecret } from "../auth.js";
 
 export function hybridAuth(realm) {
@@ -10,7 +10,9 @@ export function hybridAuth(realm) {
 
     if (authHeader.startsWith("Bearer ")) {
       try {
-        req.ctx.userId = await validateToken(authHeader.slice(7));
+        const { userId, groups } = await validateToken(authHeader.slice(7), REQUIRED_SCOPE);
+        req.ctx.userId = userId;
+        req.ctx.groups = groups;
         req.ctx.authMethod = "oidc";
         next();
       } catch (err) {

--- a/middleware/oidc.js
+++ b/middleware/oidc.js
@@ -54,7 +54,8 @@ export async function validateToken(token, requiredScope = null) {
     throw new AuthError(`Token missing required claim: ${USER_ID_CLAIM}`, 403);
   }
 
-  return userId;
+  const groups = payload.groups ?? [];
+  return { userId, groups };
 }
 
 export async function oidcAuth(req, res, next) {
@@ -63,9 +64,23 @@ export async function oidcAuth(req, res, next) {
     return res.status(401).json({ message: "Bearer token required" });
   }
   try {
-    req.ctx.userId = await validateToken(authHeader.slice(7), REQUIRED_SCOPE);
+    const { userId } = await validateToken(authHeader.slice(7), REQUIRED_SCOPE);
+    req.ctx.userId = userId;
     next();
   } catch (err) {
     return res.status(err.status || 401).json({ message: err.message });
   }
+}
+
+export function requireGroup(group) {
+  return function (req, res, next) {
+    if (req.ctx.authMethod === "secret") {
+      return next();
+    }
+    const groups = req.ctx.groups ?? [];
+    if (!groups.includes(group)) {
+      return res.status(403).json({ message: "Unauthorized!" });
+    }
+    next();
+  };
 }

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ import { syncUsers } from "./sync.js";
 import auth from "./auth.js";
 import { hybridAuth } from "./middleware/hybridAuth.js";
 import { checkAccess } from "./access.js";
+import { requireGroup } from "./oidc.js";
 
 // API routes
 import memberProjects from "./routes/memberProjects.js";
@@ -122,9 +123,9 @@ connectionPromise.then(async () => {
     memberProjects
   );
   app.use("/doors", hybridAuth("admin"), doors);
-  app.use("/admin/keys", hybridAuth("admin"), keys);
-  app.use("/admin/users", hybridAuth("admin"), users);
-  app.use("/admin/logs", hybridAuth("admin"), logs);
+  app.use("/admin/keys", hybridAuth("admin"), requireGroup("rtp"), keys);
+  app.use("/admin/users", hybridAuth("admin"), requireGroup("rtp"), users);
+  app.use("/admin/logs", hybridAuth("admin"), requireGroup("rtp"), logs);
   app.use("/mobile", mobile);
 
   client.on("connect", async () => {

--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ import { syncUsers } from "./sync.js";
 import auth from "./auth.js";
 import { hybridAuth } from "./middleware/hybridAuth.js";
 import { checkAccess } from "./access.js";
-import { requireGroup } from "./oidc.js";
+import { requireGroup } from "./middleware/oidc.js";
 
 // API routes
 import memberProjects from "./routes/memberProjects.js";


### PR DESCRIPTION
## What

Enforce group check in hybridAuth and restricts all the /admin/* routes to RTP only

## Why

hybridAuth gave everyone who auths via SSO access to these routes.

## Test Plan

tested syntax :skull: 

## Env Vars

N/A

## Documentation

N/A

## Checklist

- [x] Tested all changes locally
